### PR TITLE
fix: remove projects

### DIFF
--- a/components/CommandBar.js
+++ b/components/CommandBar.js
@@ -153,23 +153,23 @@ export default function CommandBar(props) {
     //     />
     //   ),
     // },
-    {
-      id: 'projects',
-      name: 'Projects',
-      shortcut: ['g', 'p'],
-      keywords: 'go-projects',
-      section: 'Go To',
-      perform: () => router.push('/projects'),
-      icon: (
-        <Lottie
-          lottieRef={projectsRef}
-          style={iconSize}
-          animationData={projectsIcon}
-          loop={false}
-          autoplay={false}
-        />
-      ),
-    },
+    // {
+    //   id: 'projects',
+    //   name: 'Projects',
+    //   shortcut: ['g', 'p'],
+    //   keywords: 'go-projects',
+    //   section: 'Go To',
+    //   perform: () => router.push('/projects'),
+    //   icon: (
+    //     <Lottie
+    //       lottieRef={projectsRef}
+    //       style={iconSize}
+    //       animationData={projectsIcon}
+    //       loop={false}
+    //       autoplay={false}
+    //     />
+    //   ),
+    // },
     // {
     //   id: 'work',
     //   name: 'Work',

--- a/components/Navbar.js
+++ b/components/Navbar.js
@@ -12,7 +12,7 @@ export default function Navbar() {
     'Home',
     // 'Articles',
     // 'Laravel',
-    'Projects',
+    // 'Projects',
     // 'Work',
     // // 'Podcasts',
     // // 'Investing',


### PR DESCRIPTION
This pull request includes changes to the `components/CommandBar.js` and `components/Navbar.js` files to comment out the "Projects" section. This effectively removes the "Projects" option from the command bar and the navigation bar.

Changes to `components/CommandBar.js`:

* Commented out the "Projects" command, which includes the `id`, `name`, `shortcut`, `keywords`, `section`, `perform` function, and `icon`.

Changes to `components/Navbar.js`:

* Commented out the "Projects" item in the navigation bar.